### PR TITLE
修改依赖chimee-helper的来源

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/Chimeejs/chimee-plugin-center-state#readme",
   "dependencies": {
-    "chimee-helper": "git+https://github.com/Chimeejs/chimee-helper.git",
+    "chimee-helper": "^0.2.11",
     "chimee-plugin-popup": "0.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
先多谢chimee提供播放器！

之前依赖的chimee-helper是指定的git地址，目前我们内部的构建环境只能访问npm仓库，所以希望能修改一下，多谢！